### PR TITLE
Fix: godotenv load nev error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func RegisterHandler() *httprouter.Router {
 func main() {
 	env := "dev"
 	env = os.Getenv("env")
-	if errr := godotenv.Load(".env." + env); errr != nil {
+	if errr := godotenv.Load(".env." + env); errr != nil && !os.IsNotExist(errr) {
 		fmt.Print(errr)
 	}
 


### PR DESCRIPTION
> When you call `Load()` or `Overload()` without args it returns an error `open .env: no such file or directory`. 

```diff
func main() {
-       if errr := godotenv.Load(".env." + env); errr != nil {
+	if errr := godotenv.Load(".env." + env); errr != nil && !os.IsNotExist(errr) {
		fmt.Print(errr)
}
```

> Errors returned from `godotenv.Load()` can be checked against with `os.IsNotExists(err)` to ignore the error.