### PR TITLE
Modify deprecated ioutil to io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.14
+          go-version: 1.19
         id: go
 
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.14
+          go-version: 1.19
         id: go
         
       - uses: actions/checkout@v2

--- a/handler/alipay.go
+++ b/handler/alipay.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -75,17 +75,17 @@ func FormatPrivateKey(privateKey string) string {
 	return privateKey
 }
 
-func httpPost(url string) string{
-    resp, err := http.Post(url,
-        "application/x-www-form-urlencoded",
-        strings.NewReader(""))
-    if err != nil {
-        fmt.Println(err)
-    }
-    defer resp.Body.Close()
-    body, err := ioutil.ReadAll(resp.Body)
-    if err != nil {
-        // handle error
-    }
-    return string(body)
+func httpPost(url string) string {
+	resp, err := http.Post(url,
+		"application/x-www-form-urlencoded",
+		strings.NewReader(""))
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// handle error
+	}
+	return string(body)
 }

--- a/handler/post.go
+++ b/handler/post.go
@@ -6,14 +6,14 @@ import (
 	"github.com/cliclitv/go-clicli/db"
 	"github.com/cliclitv/go-clicli/def"
 	"github.com/julienschmidt/httprouter"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
 )
 
 func AddPost(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-	req, _ := ioutil.ReadAll(r.Body)
+	req, _ := io.ReadAll(r.Body)
 	pbody := &def.Post{}
 
 	if err := json.Unmarshal(req, pbody); err != nil {
@@ -34,7 +34,7 @@ func AddPost(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 func UpdatePost(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	pid := p.ByName("id")
 	pint, _ := strconv.Atoi(pid)
-	req, _ := ioutil.ReadAll(r.Body)
+	req, _ := io.ReadAll(r.Body)
 	pbody := &def.Post{}
 	if err := json.Unmarshal(req, pbody); err != nil {
 		sendMsg(w, 400, fmt.Sprintf("%s", err))

--- a/handler/user.go
+++ b/handler/user.go
@@ -2,19 +2,18 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/cliclitv/go-clicli/db"
 	"github.com/cliclitv/go-clicli/def"
 	"github.com/cliclitv/go-clicli/util"
 	"github.com/julienschmidt/httprouter"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
-	"fmt"
 )
 
 func Register(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	req, _ := ioutil.ReadAll(r.Body)
+	req, _ := io.ReadAll(r.Body)
 	ubody := &def.User{}
 
 	if err := json.Unmarshal(req, ubody); err != nil {
@@ -38,7 +37,7 @@ func Register(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 }
 
 func Login(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	req, _ := ioutil.ReadAll(r.Body)
+	req, _ := io.ReadAll(r.Body)
 	ubody := &def.User{}
 
 	if err := json.Unmarshal(req, ubody); err != nil {
@@ -77,7 +76,7 @@ func Logout(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 
 func UpdateUser(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	pint, _ := strconv.Atoi(p.ByName("id"))
-	req, _ := ioutil.ReadAll(r.Body)
+	req, _ := io.ReadAll(r.Body)
 	ubody := &def.User{}
 	if err := json.Unmarshal(req, ubody); err != nil {
 		sendMsg(w, 400, "参数解析失败")


### PR DESCRIPTION
`ReadAll` reads from r until an error or `EOF` and returns the data it read. A successful call `returns err == nil`, not `err == EOF`. Because `ReadAll` is defined to read from src until `EOF`, it does not treat an `EOF` from Read as an error to be reported.

`Go 1.16` this function simply calls `io.ReadAll`.