### PR TITLE
Modify the actions script to avoid long-term jamming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@master
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-        id: go
+          go-version: '>=1.19.0'
+      - run: |
+          go version
 
-      - uses: actions/checkout@v2
-
-      - name: download
+      - name: download go mod
         run: |
           go mod download
+
+      - name: go build
+        run: |
           go build .
-          ./go-clicli
+
+      - name: Check file existence
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "go-clicli"
+
+      - name: File exists
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: echo "🥳"


### PR DESCRIPTION
When `GitHub Actions` executes `./go-clicli`, it will cause `Actions` to freeze for a long time, which is not good if it is considered abused. So I tried to use the method of judging whether the file exists to detect the code consistency.

Example: [actions/file-existence](https://github.com/marketplace/actions/file-existence#example).